### PR TITLE
Update DRM driver to read the resolution from xenos registers when setting up the framebuffer 

### DIFF
--- a/patch-6.18-xenon0.30.diff
+++ b/patch-6.18-xenon0.30.diff
@@ -3643,12 +3643,87 @@ index 48d30bf6152f9..1f02875c5c2aa 100644
  obj-$(CONFIG_TINYDRM_HX8357D)		+= hx8357d.o
  obj-$(CONFIG_TINYDRM_ILI9163)		+= ili9163.o
  obj-$(CONFIG_TINYDRM_ILI9225)		+= ili9225.o
+diff --git a/drivers/gpu/drm/tiny/xenos.h b/drivers/gpu/drm/tiny/xenos.h
+new file mode 100644
+index 0000000000000..1afa1898ad5c4
+--- /dev/null
++++ b/drivers/gpu/drm/tiny/xenos.h
+@@ -0,0 +1,69 @@
++/* SPDX-License-Identifier: BSD-2-Clause */
++#ifndef __XENOS_H__
++#define __XENOS_H__
++
++#define D1CRTC_UPDATE_LOCK             0x60e8
++#define DCP_LB_DATA_GAP_BETWEEN_CHUNK  0x6cbc
++#define D1CRTC_DOUBLE_BUFFER_CONTROL   0x60ec
++#define D1CRTC_V_TOTAL                 0x6020
++#define D1CRTC_H_TOTAL                 0x6000
++#define D1CRTC_H_SYNC_B                0x6010
++#define D1CRTC_H_BLANK_START_END       0x6004
++#define D1CRTC_H_SYNC_B_CNTL           0x6014
++#define D1CRTC_H_SYNC_A                0x6008
++#define D1CRTC_V_SYNC_B                0x6030
++#define D1CRTC_H_SYNC_A_CNTL           0x600c
++#define D1CRTC_MVP_INBAND_CNTL_CAP     0x604c
++#define D1CRTC_MVP_INBAND_CNTL_INSERT  0x6050
++#define D1CRTC_MVP_FIFO_STATUS         0x6044
++#define D1CRTC_MVP_SLAVE_STATUS        0x6048
++#define	D1GRPH_UPDATE                  0x6144
++#define	D1GRPH_PITCH                   0x6120
++#define	D1GRPH_CONTROL                 0x6104
++#define	D1GRPH_LUT_SEL                 0x6108
++#define	D1GRPH_SURFACE_OFFSET_X        0x6124
++#define	D1GRPH_SURFACE_OFFSET_Y        0x6128
++#define	D1GRPH_X_START                 0x612c
++#define	D1GRPH_Y_START                 0x6130
++#define	D1GRPH_X_END                   0x6134
++#define	D1GRPH_Y_END                   0x6138
++#define	D1GRPH_PRIMARY_SURFACE_ADDRESS 0x6110  
++#define	D1GRPH_ENABLE                  0x6100
++#define DC_LUT_PWL_DATA                0x6490
++#define	AVIVO_D1SCL_UPDATE             0x65cc
++#define	AVIVO_D1SCL_SCALER_ENABLE      0x6590
++#define AVIVO_D1MODE_VIEWPORT_START    0x6580
++#define AVIVO_D1MODE_VIEWPORT_SIZE     0x6584
++#define AVIVO_D1MODE_DATA_FORMAT       0x6528
++#define D1GRPH_FLIP_CONTROL            0x6148
++#define AVIVO_D1SCL_SCALER_TAP_CONTROL 0x6594
++#define DC_LUTA_CONTROL                0x64C0
++#define DC_LUT_RW_INDEX	               0x6488
++#define DC_LUT_RW_MODE                 0x6484
++#define DC_LUT_WRITE_EN_MASK	       0x649C
++#define DC_LUT_AUTOFILL      	       0x64a0
++#define D1CRTC_MVP_CONTROL1		       0x6038
++#define D1CRTC_MVP_CONTROL2		       0x603c
++#define D1CRTC_MVP_FIFO_CONTROL        0x6040
++#define AVIVO_D1CRTC_V_BLANK_START_END 0x6024
++#define D1CRTC_MVP_INBAND_CNTL_INSERT_TIMER	 0x6054
++#define D1CRTC_MVP_BLACK_KEYER	       0x6058
++#define D1CRTC_TRIGA_CNTL	           0x6060
++#define D1CRTC_TRIGA_MANUAL_TRIG	   0x6064
++#define D1CRTC_TRIGB_CNTL	           0x6068
++#define AVIVO_D1MODE_DESKTOP_HEIGHT    0x652c
++#define	D1GRPH_COLOR_MATRIX_TRANSFORMATION_CNTL   0x6380
++#define D1COLOR_MATRIX_COEF_1_1        0x6384
++#define	D1COLOR_MATRIX_COEF_1_2        0x6388
++#define	D1COLOR_MATRIX_COEF_1_3        0x638c
++#define	D1COLOR_MATRIX_COEF_1_4        0x6390
++#define	D1COLOR_MATRIX_COEF_2_1        0x6394
++#define	D1COLOR_MATRIX_COEF_2_2        0x6398
++#define	D1COLOR_MATRIX_COEF_2_3        0x639c
++#define	D1COLOR_MATRIX_COEF_2_4        0x63a0
++#define	D1COLOR_MATRIX_COEF_3_1        0x63a4
++#define	D1COLOR_MATRIX_COEF_3_2        0x63a8
++#define	D1COLOR_MATRIX_COEF_3_3        0x63ac
++#define	D1COLOR_MATRIX_COEF_3_4        0x63b0
++
++#endif
 diff --git a/drivers/gpu/drm/tiny/xenos.c b/drivers/gpu/drm/tiny/xenos.c
 new file mode 100644
-index 0000000000000..4776c3234cc5b
+index 0000000000000..f882cfecba6e0
 --- /dev/null
 +++ b/drivers/gpu/drm/tiny/xenos.c
-@@ -0,0 +1,367 @@
+@@ -0,0 +1,363 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +
 +#include <linux/aperture.h>
@@ -3684,14 +3759,12 @@ index 0000000000000..4776c3234cc5b
 +#include <drm/drm_simple_kms_helper.h>
 +#include <drm/clients/drm_client_setup.h>
 +
++#include "xenos.h"
++
 +#define DRIVER_NAME "xenos"
 +#define DRIVER_DESC "DRM framebuffer driver for Xbox 360's Xenos"
 +#define DRIVER_MAJOR 1
 +#define DRIVER_MINOR 0
-+
-+#define XENOS_D1GRPH_X_END 0x6134 
-+#define XENOS_D1GRPH_Y_END 0x6138
-+#define XENOS_AVIVO_D1MODE_DATA_FORMAT 0x6528 
 +
 +struct xenos_fb {
 +	dma_addr_t dma_addr;
@@ -3753,16 +3826,16 @@ index 0000000000000..4776c3234cc5b
 +		drm_info(&xenos->dev, "Using %dx%d (%04lx) fb\n", width, height,
 +			 xenos->real_framebuffer.size);
 +		iowrite32be(xenos->real_framebuffer.dma_addr,
-+			    xenos->regs + 0x6110);
++			    xenos->regs + D1GRPH_PRIMARY_SURFACE_ADDRESS);
 +	}
 +
-+	iowrite32be(1, xenos->regs + 0x6100);
++	iowrite32be(1, xenos->regs + D1GRPH_ENABLE);
 +}
 +
 +static void xenos_disable(struct drm_simple_display_pipe *pipe)
 +{
 +	struct xenos_device *xenos = xenos_of_pipe(pipe);
-+	iowrite32be(0, xenos->regs + 0x6100);
++	iowrite32be(0, xenos->regs + D1GRPH_ENABLE);
 +
 +	dma_free_coherent(xenos->dev.dev, xenos->real_framebuffer.size,
 +			  xenos->real_framebuffer.vaddr,
@@ -3879,9 +3952,9 @@ index 0000000000000..4776c3234cc5b
 +	struct drm_connector *connector = &xenos->connector;
 +	int ret;
 +
-+	uint32_t fb_width = ioread32be(xenos->regs + XENOS_D1GRPH_X_END);
-+	uint32_t fb_height = ioread32be(xenos->regs + XENOS_D1GRPH_Y_END);
-+	uint32_t is_progressive = ioread32be(xenos-> regs + XENOS_AVIVO_D1MODE_DATA_FORMAT);
++	uint32_t fb_width = ioread32be(xenos->regs + D1GRPH_X_END);
++	uint32_t fb_height = ioread32be(xenos->regs + D1GRPH_Y_END);
++	uint32_t is_progressive = ioread32be(xenos->regs + AVIVO_D1MODE_DATA_FORMAT);
 +
 +	if(is_progressive)
 +	{

--- a/patch-6.18-xenon0.30.diff
+++ b/patch-6.18-xenon0.30.diff
@@ -3648,7 +3648,7 @@ new file mode 100644
 index 0000000000000..4776c3234cc5b
 --- /dev/null
 +++ b/drivers/gpu/drm/tiny/xenos.c
-@@ -0,0 +1,353 @@
+@@ -0,0 +1,367 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +
 +#include <linux/aperture.h>
@@ -3688,6 +3688,10 @@ index 0000000000000..4776c3234cc5b
 +#define DRIVER_DESC "DRM framebuffer driver for Xbox 360's Xenos"
 +#define DRIVER_MAJOR 1
 +#define DRIVER_MINOR 0
++
++#define XENOS_D1GRPH_X_END 0x6134 
++#define XENOS_D1GRPH_Y_END 0x6138
++#define XENOS_AVIVO_D1MODE_DATA_FORMAT 0x6528 
 +
 +struct xenos_fb {
 +	dma_addr_t dma_addr;
@@ -3875,9 +3879,18 @@ index 0000000000000..4776c3234cc5b
 +	struct drm_connector *connector = &xenos->connector;
 +	int ret;
 +
-+	static const struct drm_display_mode mode = { DRM_MODE_INIT(
-+		60, 1280, 720, DRM_MODE_RES_MM(1280, 96ul),
-+		DRM_MODE_RES_MM(720, 96ul)) };
++	uint32_t fb_width = ioread32be(xenos->regs + XENOS_D1GRPH_X_END);
++	uint32_t fb_height = ioread32be(xenos->regs + XENOS_D1GRPH_Y_END);
++	uint32_t is_progressive = ioread32be(xenos-> regs + XENOS_AVIVO_D1MODE_DATA_FORMAT);
++
++	if(is_progressive)
++	{
++		fb_height = fb_height / 2;
++	}
++
++	struct drm_display_mode mode = { DRM_MODE_INIT(
++		60, fb_width, fb_height, DRM_MODE_RES_MM(fb_width, 96ul),
++		DRM_MODE_RES_MM(fb_height, 96ul)) };
 +	static const uint32_t formats[] = { DRM_FORMAT_XRGB8888 };
 +
 +	ret = drmm_mode_config_init(dev);

--- a/patch-6.18-xenon0.30.diff
+++ b/patch-6.18-xenon0.30.diff
@@ -3914,7 +3914,7 @@ index 0000000000000..4776c3234cc5b
 +
 +	drm_connector_helper_add(connector, &xenos_connector_helper_funcs);
 +	drm_connector_set_panel_orientation_with_quirk(
-+		connector, DRM_MODE_PANEL_ORIENTATION_UNKNOWN, 1280, 720);
++		connector, DRM_MODE_PANEL_ORIENTATION_UNKNOWN, fb_width, fb_height);
 +
 +	ret = drm_simple_display_pipe_init(dev, &xenos->pipe, &xenos_pipe_funcs,
 +					   formats, ARRAY_SIZE(formats), NULL,


### PR DESCRIPTION
Currently, the DRM driver sets up a 1280x720 framebuffer. Changes in this PR update the DRM driver to read the following xenos registers that XeLL writes to when setting the video mode:
- D1GRPH_X_END
- D1GRPH_Y_END
- XENOS_AVIVO_D1MODE_DATA_FORMAT

This is based on what the libxenon xenos driver does:

https://github.com/Free60Project/libxenon/blob/master/libxenon/drivers/xenos/xenos.c#L362